### PR TITLE
Updated documentation for ServX setup

### DIFF
--- a/content/Scripting/_index.md
+++ b/content/Scripting/_index.md
@@ -2,7 +2,7 @@
 title: "Scripting"
 titleIcon: "fa-solid fa-scroll"
 categories: ["Scripting"]
-weight: 1
+weight: 3
 ---
 
 ServX is powered by scripts. The [Templates](/scripting/template) use XML to define certain aspects of [GameObj](/lua/gameobj) that can be created/spawned. Each GameObj can have scripts or 'modules' attached to them. These attached scripts allow registering events to be handled on that GameObj. Also ServX loads the scripts/globals/main.lua file and all files [require](/lua/require)d within.

--- a/content/Setup/install.md
+++ b/content/Setup/install.md
@@ -7,7 +7,7 @@ draft: false
 weight: 2
 ---
 
-# SteamCMD
+## SteamCMD
 
 ---
 
@@ -22,6 +22,16 @@ ServX can be installed and kept up-to-date using the following SteamCMD script:
     app_update 2241750 validate
     quit
 
+Note: SteamCMD recommends having a separate account to run dedicated servers but the account used to login must have CODEX in its game library.
+
 If you prefer, you can save this snippet to a file such as *update_servx.txt* then run:
 
     steamcmd.exe +runscript D:\my_server\update_servx.txt
+
+## Prerequisites
+
+---
+
+ServX relies on the [.Net 6.0 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+
+![.Net 6.0 Runtime](/images/net-runtime.png)

--- a/content/Setup/introduction.md
+++ b/content/Setup/introduction.md
@@ -33,4 +33,4 @@ The final folder structure could then look something like this:
     servx
     stones
 
-With *rundir* containing the configuration files and acting as our *current working directory*
+With *rundir* containing the configuration files and acting as our *current working directory*.

--- a/content/Setup/lua.md
+++ b/content/Setup/lua.md
@@ -4,7 +4,7 @@ titleIcon: "fa-regular fa-file-code"
 categories: ["Setup"]
 date: 2023-07-03T14:12:32-06:00
 draft: false
-weight: 5
+weight: 3
 ---
 
 # Lua

--- a/content/Setup/map.md
+++ b/content/Setup/map.md
@@ -10,3 +10,5 @@ weight: 4
 # Map
 
 The map in stones/mapdata/Stones will need to be loaded in [World Creator](/worldcreator) and exported before ServX will run with the default configuration.
+
+Open CODEX and go to the World Creator. This will open with a new world. Go to File -> Open. Navigate to *stones\mapdata\Stones* and select this folder. Do not navigate down into *raw*. Once the Stones map has been loaded, go to File -> Export and wait for the export to finish. You should now see a *bin* folder under *stones\mapdata\Stones*.

--- a/content/Setup/run.md
+++ b/content/Setup/run.md
@@ -4,14 +4,8 @@ titleIcon: "fa-solid fa-terminal"
 categories: ["Setup"]
 date: 2023-07-03T14:12:32-06:00
 draft: false
-weight: 3
+weight: 5
 ---
-
-# Prerequisites
-
-ServX relies on the [.Net 6.0 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
-
-![.Net 6.0 Runtime](/images/net-runtime.png)
 
 # Run
 
@@ -21,17 +15,22 @@ Open a new Command Prompt or Powershell and navigate to your *rundir*, from ther
 
 ---
 
-### Specific Instance by Id
+## Config.xml changes ##
 
-If there is more than one Instance defined in [Config.xml](/config) a specific instance can be started by passing the Id:
+If this is the first time ServX has been run or you want a clean Config.xml file, immediately terminate the program (Ctrl+C) after a Config.xml has been created, change the [Config.xml](/setup/config) as necessary, and run ServX again.
+
+## Specific Instance by Id
+
+If there is more than one Instance defined in Config.xml a specific instance can be started by passing the Id:
 
     ..\servx\ServX.exe MyCluster.Stones
 
-
-# Confirm Running
+## Confirm Running
 
 When ServX is ready to be connected to you will see:
 
     Accepting Users
 
-If this is your first run or you want a clean Config.xml file, immediately terminate the program (Ctrl+C) after a Config.xml has been created, change the Config.xml as necessary, and run ServX again.
+## Errors
+
+If errors are encountered when trying to run ServX for the first time, ensure that all installation steps have been completed, including the installation of the .NET [prerequisites](/setup/install/#prerequisites), the [lua](/setup/lua) scripts, and export of the Stones [map](/setup/map). For other errors, see the [errors](/setup/errors) documentation.

--- a/content/WorldCreator/_index.md
+++ b/content/WorldCreator/_index.md
@@ -2,7 +2,7 @@
 title: "World Creator"
 titleIcon: "fa-solid fa-map"
 categories: ["WorldCreator"]
-weight: 1
+weight: 2
 ---
 
 This World Creator is a tool to make map for use in CODEX.


### PR DESCRIPTION
Reordered pages to help prevent errors on running when map and lua haven't been set up yet. Added information about possible errors. Moved prereqs into install page to keep installation tasks together. Added further explanation of map export steps.